### PR TITLE
Streamline initialization and add Rviz goal height param

### DIFF
--- a/faster/include/faster_ros.hpp
+++ b/faster/include/faster_ros.hpp
@@ -190,4 +190,7 @@ private:
 
   int actual_trajID_ = 0;
   // faster_msgs::Mode mode_;
+
+  // Params specific to ROS wrapper
+  double rviz_goal_height_ = 1.;  // [m] Assumed height for clicked 2d nav goals in Rviz  (overridden for ground robots)
 };

--- a/faster/param/faster.yaml
+++ b/faster/param/faster.yaml
@@ -5,6 +5,7 @@ visual: true #publish visualization stuff
 dc: 0.01            #(seconds) Duration for the interpolation=Value of the timer pubGoal
 goal_radius: 0.3    #[m] Drone has arrived to the goal when distance_to_goal<GOAL_RADIUS
 drone_radius: 0.3  #[m] Used for collision checking
+rviz_goal_height: 1  #[m] Assumed height for clicked 2d nav goals in Rviz  (overridden for ground robots)
 
 N_whole: 6 #[-] Number of discretization points in the whole trajectory
 N_safe: 6 #[-] Number of discretization points in the safe path

--- a/faster/src/faster_ros.cpp
+++ b/faster/src/faster_ros.cpp
@@ -18,6 +18,7 @@ FasterRos::FasterRos(ros::NodeHandle nh) : nh_(nh)
   safeGetParam(nh_, "dc", par_.dc);
   safeGetParam(nh_, "goal_radius", par_.goal_radius);
   safeGetParam(nh_, "drone_radius", par_.drone_radius);
+  safeGetParam(nh_, "rviz_goal_height", rviz_goal_height_);
 
   safeGetParam(nh_, "N_safe", par_.N_safe);
   safeGetParam(nh_, "N_whole", par_.N_whole);
@@ -499,7 +500,7 @@ void FasterRos::pubState(const state& data, const ros::Publisher pub)
 void FasterRos::terminalGoalCB(const geometry_msgs::PoseStamped& msg)
 {
   state G_term;
-  double height = (par_.is_ground_robot) ? 0.2 : 1.0;  // TODO
+  const double height = (par_.is_ground_robot) ? 0.2 : rviz_goal_height_;
   G_term.setPos(msg.pose.position.x, msg.pose.position.y, height);
   faster_ptr_->setTerminalGoal(G_term);
 

--- a/faster/src/faster_ros.cpp
+++ b/faster/src/faster_ros.cpp
@@ -112,6 +112,10 @@ FasterRos::FasterRos(ros::NodeHandle nh) : nh_(nh)
     }
   */
 
+  // Initialize FASTER
+  faster_ptr_ = std::unique_ptr<Faster>(new Faster(par_));
+  ROS_INFO("Planner initialized");
+
   // Publishers
   // pub_goal_jackal_ = nh_.advertise<geometry_msgs::Twist>("goal_jackal", 1);
   pub_goal_ = nh_.advertise<snapstack_msgs::QuadGoal>("goal", 1);
@@ -173,10 +177,6 @@ FasterRos::FasterRos(ros::NodeHandle nh) : nh_(nh)
   // &FasterRos::replanCB, this);
 
   clearMarkerActualTraj();
-
-  faster_ptr_ = std::unique_ptr<Faster>(new Faster(par_));
-
-  ROS_INFO("Planner initialized");
 }
 
 void FasterRos::replanCB(const ros::TimerEvent& e)

--- a/faster/src/faster_ros.cpp
+++ b/faster/src/faster_ros.cpp
@@ -172,24 +172,6 @@ FasterRos::FasterRos(ros::NodeHandle nh) : nh_(nh)
   // If you want another thread for the replanCB: replanCBTimer_ = nh_.createTimer(ros::Duration(par_.dc),
   // &FasterRos::replanCB, this);
 
-  name_drone_ = ros::this_node::getNamespace();
-  name_drone_.erase(std::remove(name_drone_.begin(), name_drone_.end(), '/'), name_drone_.end());  // remove slashes
-
-  tfListener = new tf2_ros::TransformListener(tf_buffer_);
-  // wait for body transform to be published before initializing
-  ROS_INFO("Waiting for world to camera transform...");
-  while (true)
-  {
-    try
-    {
-      tf_buffer_.lookupTransform(world_name_, name_drone_ + "/camera", ros::Time::now(), ros::Duration(0.5));  //
-      break;
-    }
-    catch (tf2::TransformException& ex)
-    {
-      // nothing
-    }
-  }
   clearMarkerActualTraj();
 
   faster_ptr_ = std::unique_ptr<Faster>(new Faster(par_));


### PR DESCRIPTION
A few minor things here to generalize application and smooth out potential issues for new users:

* The (infinite) wait for world->camera doesn't seem necessary for Faster (it doesn't seem to use this transform). If this is a requirement for system performance / flight in hardware, this check should probably happen elsewhere in the system, and definitely not within a class constructor. It also assumes a hardcoded "quad_name/camera" transform naming which is not entirely general.

* Minor point to initialize the internal `Faster` object pointer *before* starting subscribers/callbacks that may rely on it.

* Adds a ROS param `rviz_goal_height` to specify a desired z-value for 2d nav goals specified in Rviz (rather than the hard-coded 1m).